### PR TITLE
Change the order when password is set for redis

### DIFF
--- a/src/PhpRedisAdapter.php
+++ b/src/PhpRedisAdapter.php
@@ -20,8 +20,8 @@ class PhpRedisAdapter extends AbstractRedisRawClient
     {
         $this->redis = new Redis();
         $this->redis->connect($hostname, $port);
-        $this->redis->select($db);
         $this->redis->auth($password);
+        $this->redis->select($db);
         return $this;
     }
 


### PR DESCRIPTION
I came across an erorr when the Redis password is set. Sample code is as 

```
$redis = (new \Ehann\RedisRaw\PhpRedisAdapter())->connect(
	'127.0.0.1',
	'6379',
	0,
	'password'
);
```


```
When RedisException: NOAUTH Authentication required. in file /experiments/vendor/ethanhann/redis-raw/src/PhpRedisAdapter.php on line 23
Stack trace:
  1. RedisException->() /experiments/vendor/ethanhann/redis-raw/src/PhpRedisAdapter.php:23
  2. Redis->select() /experiments/vendor/ethanhann/redis-raw/src/PhpRedisAdapter.php:23

```