### PR TITLE
Adds PHP 8.3 support

### DIFF
--- a/src/AbstractRedisRawClient.php
+++ b/src/AbstractRedisRawClient.php
@@ -14,7 +14,7 @@ abstract class AbstractRedisRawClient implements RedisRawClientInterface
     public const REDIS_CLIENT_LIBRARY = 'RedisClient';
 
     public $redis;
-    protected LoggerInterface $logger;
+    protected ?LoggerInterface $logger = null;
 
     public function connect($hostname = '127.0.0.1', $port = 6379, $db = 0, $password = null): RedisRawClientInterface
     {


### PR DESCRIPTION
Fixes

- Fatal error: Uncaught Error: Typed property Ehann\RedisRaw\AbstractRedisRawClient::$logger must not be accessed before initialization in redis-raw\src\AbstractRedisRawClient.php:40